### PR TITLE
[TI-53368] Image is  not perfectly fit to the page in the left panel when opened first time

### DIFF
--- a/projects/angular-image-viewer/src/lib/angular-image-viewer.component.scss
+++ b/projects/angular-image-viewer/src/lib/angular-image-viewer.component.scss
@@ -1,12 +1,27 @@
 .img-container {
+  position: relative;
   width: 100%;
+  height: 100%;
   display: flex;
   justify-content: center;
   align-items: center;
   overflow: hidden;
 
   .drag-element {
+    position: absolute;
+    top: 35px;
+    right: 78px;
+    width: calc(100% - 156px);
+    height: calc(100% - 85px);
     cursor: grab;
+    text-align: center;
+    
+    img {
+     padding: 0;
+     max-width: 100%;
+     max-height: 100%;
+    }
+
     &:active {
       cursor:grabbing;
     }


### PR DESCRIPTION
Kindly check the below Jira link and Screenshot for your reference.
https://jira.clarivate.io/browse/TI-53368

Small Image
![image](https://user-images.githubusercontent.com/51233927/96731862-59c55b00-13d5-11eb-9f4a-28c6e1cf6348.png)

**Higher resolution image**
Before fix
![image](https://user-images.githubusercontent.com/51233927/96732052-8e391700-13d5-11eb-983a-ea94e6759769.png)

After fix
![image](https://user-images.githubusercontent.com/51233927/96732185-b0329980-13d5-11eb-81ae-6695af4a0cb1.png)
